### PR TITLE
Specify default goal and fix clang by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,10 @@ LOCALEDIR   = $(DATADIR)/locale
 
 VERSION = 0.23 Beta
 
-clang: $(eval CXX=clang++) all
+.DEFAULT_GOAL := all
+
+clang: CXX=clang++
+clang: all
 
 all:$(EXECUTABLE) langs
 


### PR DESCRIPTION
By default, make takes the first target as the default one, which made clang the default.

.DEFAULT_GOAL is a special variable that tells make what should be built by default.

Also, $(eval ...) was causing make to always replace the value of CXX, which is wrong.

This is now the correct behaviour.