### PR TITLE
Fix build for wxWidgets 3.1.2

### DIFF
--- a/src/HexDialogs.cpp
+++ b/src/HexDialogs.cpp
@@ -420,7 +420,7 @@ void FindDialog::OnChar( wxKeyEvent& event ){
 	}
 
 void FindDialog::EventHandler( wxCommandEvent& event ){
-	WX_CLEAR_ARRAY(parent->HighlightArray )
+	WX_CLEAR_ARRAY(parent->HighlightArray);
 	parent->HighlightArray.Shrink();
 
 	if( event.GetId() == btnFind->GetId())

--- a/src/HexEditorCtrl/HexEditorCtrl.cpp
+++ b/src/HexEditorCtrl/HexEditorCtrl.cpp
@@ -64,9 +64,9 @@ HexEditorCtrl::~HexEditorCtrl( void ){
 	Dynamic_Disconnector();
 	Clear();
 
-	WX_CLEAR_ARRAY(MainTagArray)
-	WX_CLEAR_ARRAY(HighlightArray)
-   WX_CLEAR_ARRAY(CompareArray)
+	WX_CLEAR_ARRAY(MainTagArray);
+	WX_CLEAR_ARRAY(HighlightArray);
+	WX_CLEAR_ARRAY(CompareArray);
 
    MainTagArray.Shrink();
    HighlightArray.Shrink();


### PR DESCRIPTION
wxWidgets 3.1.2 changed WX_CLEAR_ARRAY from a macro to inline function and as a result, WX_CLEAR_ARRAY requires semicolons at the end. Problem also reported in issue #133 .