### PR TITLE
Generate and upload AppImage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,23 @@
+language: cpp
+compiler: gcc
+sudo: require
+dist: xenial
+
+install:
+  - sudo apt-get -y install  build-essential libwxgtk3.0-dev libmhash-dev libdisasm-dev
+
+script:
+  - sed -i -e 's| -lgomp||g' Makefile # FIXME: https://github.com/EUA/wxHexEditor/issues/150#issuecomment-575944402
+  - sed -i -e 's|/usr/local|appdir/usr|g' Makefile # FIXME: https://github.com/probonopd/linuxdeployqt#for-projects-that-use-cmake-autotools-or-meson-with-ninja-instead-of-qmake
+  - make -j$(nproc)
+  - sudo make install ; sudo mv /appdir . ; sudo chown -R $USER appdir ; find appdir/ # FIXME: https://github.com/probonopd/linuxdeployqt#for-projects-that-use-cmake-autotools-or-meson-with-ninja-instead-of-qmake
+  - cp appdir/usr/share/pixmaps/wxHexEditor.png appdir/
+  - wget -c -nv https://github.com/$(wget -q https://github.com/probonopd/go-appimage/releases -O - | grep "appimagetool-.*-x86_64.AppImage" | head -n 1 | cut -d '"' -f 2)
+  - chmod +x ./appimagetool-*.AppImage
+  - ./appimagetool-*.AppImage deploy appdir/usr/share/applications/*.desktop
+  - ./appimagetool-*.AppImage appdir/
+
+# do not build tags that we create when we upload to GitHub Releases
+branches:
+  except:
+    - /^(?i:continuous)/

--- a/resources/wxHexEditor.desktop
+++ b/resources/wxHexEditor.desktop
@@ -8,6 +8,6 @@ Exec=wxHexEditor
 Icon=wxHexEditor
 Terminal=false
 Type=Application
-Categories=Utility;TextEditor;Utility;
-Keywords[en_GB]=disk;drive;volume;harddisk;hdd;disc;cdrom;dvd;partition;iso;image;backup;restore;editor;
+Categories=Utility;TextEditor;
+Keywords=disk;drive;volume;harddisk;hdd;disc;cdrom;dvd;partition;iso;image;backup;restore;editor;
 


### PR DESCRIPTION
This PR, when merged, will compile this application on [Travis CI](https://travis-ci.org/) upon each `git push`, and upload an [AppImage](http://appimage.org/) to your GitHub Releases page.

Providing an [AppImage](http://appimage.org/) would have, among others, these advantages:
- Applications packaged as an AppImage can run on many distributions (including Ubuntu, Fedora, openSUSE, CentOS, elementaryOS, Linux Mint, and others)
- One app = one file = super simple for users: just download one AppImage file, [make it executable](http://discourse.appimage.org/t/how-to-make-an-appimage-executable/80), and run
- No unpacking or installation necessary
- No root needed
- No system libraries changed
- Works out of the box, no installation of runtimes needed
- Optional desktop integration with `appimaged`
- Optional binary delta updates, e.g., for continuous builds (only download the binary diff) using AppImageUpdate
- Can optionally GPG2-sign your AppImages (inside the file)
- Works on Live ISOs
- Can use the same AppImages when dual-booting multiple distributions
- Can be listed in the [AppImageHub](https://appimage.github.io/) central directory of available AppImages
- Can double as a self-extracting compressed archive with the `--appimage-extract` parameter
- No repositories needed. Suitable/optimized for air-gapped (offline) machines
- Decentralized

[Here is an overview](https://appimage.github.io/apps) of projects that are already distributing upstream-provided, official AppImages.

__PLEASE NOTE: For this to work, you need to set up `GITHUB_TOKEN` in Travis CI for this to work; please see https://github.com/probonopd/uploadtool.__

If you have questions, AppImage developers are on #AppImage on irc.freenode.net.